### PR TITLE
fix(theme): limpiar estilos globales y hacer funcional el toggle de tema

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,26 +1,26 @@
 @import "tailwindcss";
 
-:root {
-  --background: #ffffff;
-  --foreground: #171717;
+/* === Tema controlado por CLASE en <html> (no por :root ni prefers-color-scheme) === */
+@layer base {
+  html { @apply bg-white text-zinc-900; }
+  html.dark { @apply bg-zinc-950 text-zinc-100; }
+
+  body { @apply min-h-dvh antialiased; }
 }
 
-@theme inline {
-  --color-background: var(--background);
-  --color-foreground: var(--foreground);
-  --font-sans: var(--font-geist-sans);
-  --font-mono: var(--font-geist-mono);
-}
-
-@media (prefers-color-scheme: dark) {
-  :root {
-    --background: #0a0a0a;
-    --foreground: #ededed;
+/* (Opcional pero recomendable) normaliza controles de formulario */
+@layer base {
+  :where(textarea, input, select, button){
+    -webkit-appearance: none;
+    appearance: none;
+    background: transparent;
+    border: 0;
+    outline: 0;
   }
+  :where(textarea, input)::placeholder{
+    @apply text-zinc-400 dark:text-zinc-500;
+  }
+  :where(textarea, input, select){ color-scheme: light; }
+  html.dark :where(textarea, input, select){ color-scheme: dark; }
 }
 
-body {
-  background: var(--background);
-  color: var(--foreground);
-  font-family: Arial, Helvetica, sans-serif;
-}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -6,42 +6,26 @@ import { ThemeProvider } from "@/components/providers/ThemeProvider";
 import ThemeToggle from "@/components/ThemeToggle";
 import { Toaster } from "sonner";
 
-const geistSans = Geist({
-  variable: "--font-geist-sans",
-  subsets: ["latin"],
-});
-
-const geistMono = Geist_Mono({
-  variable: "--font-geist-mono",
-  subsets: ["latin"],
-});
+const geistSans = Geist({ variable: "--font-geist-sans", subsets: ["latin"] });
+const geistMono = Geist_Mono({ variable: "--font-geist-mono", subsets: ["latin"] });
 
 export const metadata: Metadata = {
   title: "Kopy+",
   description: "Multi-clipboard minimal. Crea, guarda y copia tus clips fácilmente.",
 };
 
-export default function RootLayout({
-  children,
-}: Readonly<{
-  children: React.ReactNode;
-}>) {
+export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
-    <html lang="es" suppressHydrationWarning>
-      <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased bg-white text-zinc-900 dark:bg-zinc-950 dark:text-zinc-100`}
-      >
+    <html lang="es" suppressHydrationWarning className={`${geistSans.variable} ${geistMono.variable}`}>
+      <body>
         <ThemeProvider>
           <div className="mx-auto max-w-3xl px-4 py-6">
             <header className="mb-6 flex items-center justify-between">
               <h1 className="text-xl font-semibold">Kopy+</h1>
               <ThemeToggle />
             </header>
-
             {children}
           </div>
-
-          {/* Toasts globales */}
           <Toaster richColors position="top-right" />
         </ThemeProvider>
       </body>

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -4,21 +4,31 @@ import { Moon, Sun } from "lucide-react";
 import { useEffect, useState } from "react";
 
 export default function ThemeToggle() {
-  const { theme, setTheme, systemTheme } = useTheme();
+  const { theme, resolvedTheme, setTheme } = useTheme();
   const [mounted, setMounted] = useState(false);
   useEffect(() => setMounted(true), []);
-
-  const current = theme === "system" ? systemTheme : theme;
   if (!mounted) return null;
+
+  const isDark = (theme === "dark") || (theme === "system" && resolvedTheme === "dark");
 
   return (
     <button
+      type="button"
       aria-label="Cambiar tema"
-      onClick={() => setTheme(current === "dark" ? "light" : "dark")}
-      className="inline-flex items-center gap-2 rounded-xl border px-3 py-2 text-sm hover:bg-zinc-50 dark:hover:bg-zinc-900"
+      onClick={() => setTheme(isDark ? "light" : "dark")}
+      className="inline-flex items-center gap-2 rounded-2xl px-3 py-2 text-sm
+                 border shadow-sm backdrop-blur
+                 bg-white/80 border-zinc-200 hover:bg-white
+                 text-zinc-700 hover:text-zinc-900
+                 dark:bg-zinc-900/70 dark:border-zinc-700/60 dark:hover:bg-zinc-900
+                 dark:text-zinc-200 dark:hover:text-white
+                 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500/60
+                 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-zinc-950
+                 transition-colors"
     >
-      {current === "dark" ? <Sun size={16} /> : <Moon size={16} />}
-      <span className="hidden sm:inline">{current === "dark" ? "Claro" : "Oscuro"}</span>
+      {isDark ? <Sun size={16} /> : <Moon size={16} />}
+      <span className="hidden sm:inline">{isDark ? "Claro" : "Oscuro"}</span>
     </button>
   );
 }
+

--- a/src/components/providers/ThemeProvider.tsx
+++ b/src/components/providers/ThemeProvider.tsx
@@ -4,7 +4,13 @@ import React from "react";
 
 export function ThemeProvider({ children }: { children: React.ReactNode }) {
   return (
-    <NextThemesProvider attribute="class" defaultTheme="system" enableSystem>
+    <NextThemesProvider
+      attribute="class"          // pone/quita "dark" en <html>
+      enableSystem={false}       // NO seguir el sistema: manda el toggle
+      defaultTheme="light"       // arranque
+      storageKey="kopyplus-theme"// clave clara en localStorage
+      disableTransitionOnChange  // sin parpadeos
+    >
       {children}
     </NextThemesProvider>
   );

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,11 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  darkMode: "class",
+  content: [
+    "./src/pages/**/*.{js,ts,jsx,tsx,mdx}",
+    "./src/components/**/*.{js,ts,jsx,tsx,mdx}",
+    "./src/app/**/*.{js,ts,jsx,tsx,mdx}",
+  ],
+  theme: { extend: {} },
+  plugins: [],
+};


### PR DESCRIPTION
Este PR corrige el control del modo oscuro y claro en la aplicación:
- Se eliminan estilos globales conflictivos en `globals.css`.
- Se habilita el uso de `darkMode: "class"` en Tailwind.
- Se configura `ThemeProvider` correctamente con `next-themes`.
- El botón de toggle ahora cambia entre claro y oscuro sin depender del navegador.
